### PR TITLE
위치 권한 두 번째 요청 시 허용 여부에 관계 없이 거부했다는 토스트 메시지가 나오는 현상 해결

### DIFF
--- a/app/src/main/java/com/pob/seeat/presentation/view/PermissionGuideActivity.kt
+++ b/app/src/main/java/com/pob/seeat/presentation/view/PermissionGuideActivity.kt
@@ -13,7 +13,6 @@ import com.pob.seeat.presentation.view.sign.LoginActivity
 import com.pob.seeat.utils.PermissionSupport
 
 class PermissionGuideActivity : AppCompatActivity() {
-    private var isRequested: Boolean = false
 
     private val binding: ActivityPermissionGuideBinding by lazy {
         ActivityPermissionGuideBinding.inflate(
@@ -45,16 +44,20 @@ class PermissionGuideActivity : AppCompatActivity() {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         if (PermissionSupport.permissionResult(requestCode, grantResults)) {
             // 권한을 허용한 경우
-            if (isRequested) Toast.makeText(
-                this@PermissionGuideActivity, "위치 권한 사용을 거부했습니다.", Toast.LENGTH_SHORT
-            ).show()
             val intent = Intent(this@PermissionGuideActivity, LoginActivity::class.java)
             startActivity(intent)
         } else {
             // 권한을 거부한 경우
-            Toast.makeText(this, "앱 실행을 위해서는 권한을 설정해야 합니다.", Toast.LENGTH_SHORT).show()
-            PermissionSupport.checkLocationPermissions(this@PermissionGuideActivity)
-            isRequested = true
+            if (requestCode == PermissionSupport.RETRY_PERMISSIONS) {
+                Toast.makeText(
+                    this@PermissionGuideActivity, "위치 권한 사용을 거부했습니다.", Toast.LENGTH_SHORT
+                ).show()
+                val intent = Intent(this@PermissionGuideActivity, LoginActivity::class.java)
+                startActivity(intent)
+            } else {
+                Toast.makeText(this, "앱 실행을 위해서는 권한을 설정해야 합니다.", Toast.LENGTH_SHORT).show()
+                PermissionSupport.checkLocationPermissions(this@PermissionGuideActivity)
+            }
         }
     }
 }

--- a/app/src/main/java/com/pob/seeat/utils/PermissionSupport.kt
+++ b/app/src/main/java/com/pob/seeat/utils/PermissionSupport.kt
@@ -10,7 +10,7 @@ import com.pob.seeat.utils.dialog.Dialog
 
 object PermissionSupport {
     private const val MULTIPLE_PERMISSIONS = 1023 // 위치 권한 요청 코드
-    private const val RETRY_PERMISSIONS = 1024 // 재요청 코드
+    const val RETRY_PERMISSIONS = 1024 // 재요청 코드
 
     // 요청할 권한 배열 저장
     private val permissionNeeded = listOf(
@@ -47,14 +47,13 @@ object PermissionSupport {
     // 요청한 권한에 대한 결과값 판단 및 처리
     fun permissionResult(requestCode: Int, grantResults: IntArray): Boolean {
         return when (requestCode) {
-            MULTIPLE_PERMISSIONS -> {
+            MULTIPLE_PERMISSIONS, RETRY_PERMISSIONS -> {
                 // -1 (거부된 권한)이 있는지 체크하여 거부된 것이 있다면 false 반환
                 return permissionNeeded.filterIndexed { index, _ ->
                     grantResults[index] == PackageManager.PERMISSION_DENIED
                 }.isEmpty()
             }
 
-            RETRY_PERMISSIONS -> true
             else -> false
         }
     }


### PR DESCRIPTION
## 🏷️ 관련 이슈

<!-- 관련된 이슈의 번호를 작성해주세요. -->
- close #225 

## 🔎 작업 내용

<!-- 작업에 대해 상세히 설명해주세요. -->
- 기존에는 두 번째 권한 요청 허용 여부와 관계 없이 무조건 true를 반환하도록 구녛되어 있었음
- 두 번째 권한 요청시에도, 허용 여부에 따라 true 혹은 false를 반환하게 해 요청 코드로 판단 후 토스트 메시지를 띄우도록 변경
